### PR TITLE
Add offline Plasticity radial menu editor bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# -
-使用spec流程进行刘慈欣风格仿写测试
+# Cixin-Liu-genre-imitation-with-AI
+
+## Offline Plasticity radial menu editor
+
+This repository now bundles an offline clone of PepperKUN's Plasticity radial menu editor. Copy the [`offline-radial-menu-editor`](offline-radial-menu-editor/) directory anywhere inside your internal network and open `index.html` in a browser to start editing Plasticity radial menu presets without internet access.
+
+See the [tool README](offline-radial-menu-editor/README.md) for usage instructions.

--- a/offline-radial-menu-editor/README.md
+++ b/offline-radial-menu-editor/README.md
@@ -1,0 +1,42 @@
+# Plasticity Radial Menu Editor (Offline bundle)
+
+This directory contains a self-contained, browser-based editor for building Plasticity radial menu presets. Every dependency is bundled locally so the tool can run without an internet connection.
+
+## Usage
+
+1. Copy the entire `offline-radial-menu-editor` directory to a machine inside your internal network.
+2. Open the `index.html` file in any modern browser (Chrome, Edge, Firefox, Safari).
+3. Add slices, edit their labels, colours, key bindings, and commands.
+4. Export the preset as JSON and import it into Plasticity.
+
+The editor automatically saves your work to `localStorage`, so your latest session will be restored the next time you open the page from the same browser.
+
+## Importing existing presets
+
+The tool accepts JSON files with the following structure:
+
+```json
+{
+  "meta": {
+    "innerRadius": 0.35,
+    "gapAngle": 2,
+    "backgroundColor": "#1b1d26"
+  },
+  "items": [
+    {
+      "label": "Modeling",
+      "command": "Loft",
+      "keybind": "Shift+1",
+      "icon": "M",
+      "color": "#6dcff6",
+      "weight": 1
+    }
+  ]
+}
+```
+
+The editor ignores unknown properties, so you can import data exported from older versions as long as they include an `items` array.
+
+## Development notes
+
+The application is written in plain HTML, CSS, and JavaScript to avoid network-bound package managers. The canvas preview updates live as you modify slices, and all helpers (such as JSON export and clipboard copy) are implemented without third-party libraries to keep the bundle lightweight and portable.

--- a/offline-radial-menu-editor/app.js
+++ b/offline-radial-menu-editor/app.js
@@ -1,0 +1,542 @@
+(() => {
+  const state = {
+    items: [],
+    selectedId: null,
+    innerRadius: 0.35,
+    gapAngle: 2,
+    backgroundColor: '#1b1d26'
+  };
+
+  const STORAGE_KEY = 'plasticity-radial-menu-editor';
+  let idCounter = 1;
+
+  const elements = {
+    addItem: document.getElementById('add-item'),
+    duplicateItem: document.getElementById('duplicate-item'),
+    removeItem: document.getElementById('remove-item'),
+    moveUp: document.getElementById('move-up'),
+    moveDown: document.getElementById('move-down'),
+    itemList: document.getElementById('item-list'),
+    itemEditor: document.getElementById('item-editor'),
+    itemLabel: document.getElementById('item-label'),
+    itemCommand: document.getElementById('item-command'),
+    itemKeybind: document.getElementById('item-keybind'),
+    itemIcon: document.getElementById('item-icon'),
+    itemColor: document.getElementById('item-color'),
+    itemWeight: document.getElementById('item-weight'),
+    itemWeightValue: document.getElementById('item-weight-value'),
+    importFile: document.getElementById('import-file'),
+    loadJson: document.getElementById('load-json'),
+    exportJson: document.getElementById('export-json'),
+    copyJson: document.getElementById('copy-json'),
+    jsonOutput: document.getElementById('json-output'),
+    canvas: document.getElementById('menu-preview'),
+    innerRadius: document.getElementById('inner-radius'),
+    innerRadiusValue: document.getElementById('inner-radius-value'),
+    gapAngle: document.getElementById('gap-angle'),
+    gapAngleValue: document.getElementById('gap-angle-value'),
+    backgroundColor: document.getElementById('background-color')
+  };
+
+  const ctx = elements.canvas.getContext('2d');
+
+  function createItem(template) {
+    const baseColours = ['#6dcff6', '#7d7aff', '#ff9f43', '#00d1b2', '#ff5d8f', '#ffcd3c'];
+    const colour = template?.color || baseColours[(state.items.length + 3) % baseColours.length];
+    return {
+      id: template?.id ?? `item-${Date.now()}-${idCounter++}`,
+      label: template?.label || 'New Slice',
+      command: template?.command || '',
+      keybind: template?.keybind || '',
+      icon: template?.icon || '',
+      color: colour,
+      weight: template?.weight || 1
+    };
+  }
+
+  function selectItem(id) {
+    state.selectedId = id;
+    updateItemEditor();
+    renderItemList();
+    renderPreview();
+  }
+
+  function addItem(template) {
+    const item = createItem(template);
+    state.items.push(item);
+    selectItem(item.id);
+    persist();
+  }
+
+  function duplicateSelected() {
+    const item = getSelectedItem();
+    if (!item) return;
+    const clone = createItem({ ...item, id: undefined });
+    const index = state.items.findIndex((i) => i.id === item.id);
+    state.items.splice(index + 1, 0, clone);
+    selectItem(clone.id);
+    persist();
+  }
+
+  function removeSelected() {
+    const index = state.items.findIndex((item) => item.id === state.selectedId);
+    if (index === -1) return;
+    state.items.splice(index, 1);
+    if (state.items.length === 0) {
+      state.selectedId = null;
+    } else if (index < state.items.length) {
+      state.selectedId = state.items[index].id;
+    } else {
+      state.selectedId = state.items[state.items.length - 1].id;
+    }
+    updateItemEditor();
+    renderItemList();
+    renderPreview();
+    persist();
+  }
+
+  function moveSelected(offset) {
+    const index = state.items.findIndex((item) => item.id === state.selectedId);
+    if (index === -1) return;
+    const newIndex = index + offset;
+    if (newIndex < 0 || newIndex >= state.items.length) return;
+    const [item] = state.items.splice(index, 1);
+    state.items.splice(newIndex, 0, item);
+    renderItemList();
+    renderPreview();
+    persist();
+  }
+
+  function getSelectedItem() {
+    if (!state.selectedId) return null;
+    return state.items.find((item) => item.id === state.selectedId) || null;
+  }
+
+  function updateItemEditor() {
+    const item = getSelectedItem();
+    const hidden = !item;
+    elements.itemEditor.classList.toggle('hidden', hidden);
+    elements.removeItem.disabled = hidden;
+    elements.duplicateItem.disabled = hidden;
+    elements.moveUp.disabled = hidden || state.items.length <= 1 || state.items[0].id === state.selectedId;
+    elements.moveDown.disabled = hidden || state.items.length <= 1 || state.items[state.items.length - 1].id === state.selectedId;
+
+    if (!item) return;
+
+    elements.itemLabel.value = item.label;
+    elements.itemCommand.value = item.command;
+    elements.itemKeybind.value = item.keybind;
+    elements.itemIcon.value = item.icon;
+    elements.itemColor.value = item.color;
+    elements.itemWeight.value = String(item.weight);
+    elements.itemWeightValue.textContent = `${item.weight}×`;
+  }
+
+  function renderItemList() {
+    elements.itemList.innerHTML = '';
+    if (state.items.length === 0) {
+      const empty = document.createElement('li');
+      empty.textContent = 'No items yet — add your first slice.';
+      empty.className = 'empty';
+      elements.itemList.appendChild(empty);
+      return;
+    }
+
+    const totalWeight = state.items.reduce((sum, item) => sum + item.weight, 0) || 1;
+
+    state.items.forEach((item, index) => {
+      const li = document.createElement('li');
+      li.dataset.id = item.id;
+      li.classList.toggle('selected', item.id === state.selectedId);
+
+      const meta = document.createElement('div');
+      meta.className = 'item-meta';
+      const label = document.createElement('strong');
+      label.textContent = item.label || `Slice ${index + 1}`;
+      const icon = document.createElement('span');
+      icon.className = 'badge';
+      icon.textContent = item.icon || `${Math.round((item.weight / totalWeight) * 100)}%`;
+      meta.append(label, icon);
+
+      const details = document.createElement('div');
+      details.className = 'item-details';
+      details.textContent = [item.keybind, item.command].filter(Boolean).join(' · ');
+
+      const colorChip = document.createElement('div');
+      colorChip.className = 'color-chip';
+      colorChip.style.background = item.color;
+
+      li.append(meta, details, colorChip);
+      li.addEventListener('click', () => selectItem(item.id));
+      elements.itemList.appendChild(li);
+    });
+  }
+
+  function renderPreview() {
+    const { canvas } = elements;
+    const { width, height } = canvas;
+    const cx = width / 2;
+    const cy = height / 2;
+    const padding = 24;
+    const outerRadius = Math.min(width, height) / 2 - padding;
+    const innerRadius = Math.max(0, Math.min(0.85, state.innerRadius)) * outerRadius;
+    const items = state.items;
+
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = state.backgroundColor;
+    ctx.fillRect(0, 0, width, height);
+
+    if (items.length === 0) {
+      ctx.fillStyle = 'rgba(255,255,255,0.6)';
+      ctx.font = '600 20px "Inter", system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText('Add items to build your radial menu', cx, cy);
+      return;
+    }
+
+    const totalWeight = items.reduce((sum, item) => sum + item.weight, 0);
+    const gapDeg = Math.min(Number(elements.gapAngle.value) || 0, 20);
+    const gap = (gapDeg * Math.PI) / 180;
+    const usableArc = Math.max(Math.PI * 2 - gap * items.length, Math.PI * 0.5);
+    let angle = -Math.PI / 2;
+
+    items.forEach((item) => {
+      const sliceArc = usableArc * (item.weight / totalWeight);
+      const start = angle;
+      const end = start + sliceArc;
+      const arcStart = start + gap / 2;
+      const arcEnd = end - gap / 2;
+
+      ctx.beginPath();
+      ctx.moveTo(cx + Math.cos(arcStart) * innerRadius, cy + Math.sin(arcStart) * innerRadius);
+      ctx.arc(cx, cy, outerRadius, arcStart, arcEnd);
+      ctx.lineTo(cx + Math.cos(arcEnd) * innerRadius, cy + Math.sin(arcEnd) * innerRadius);
+      ctx.arc(cx, cy, innerRadius, arcEnd, arcStart, true);
+      ctx.closePath();
+
+      const gradient = ctx.createLinearGradient(cx, cy, cx + Math.cos((arcStart + arcEnd) / 2) * outerRadius, cy + Math.sin((arcStart + arcEnd) / 2) * outerRadius);
+      gradient.addColorStop(0, shadeColour(item.color, 0.1));
+      gradient.addColorStop(1, shadeColour(item.color, -0.1));
+      ctx.fillStyle = gradient;
+      ctx.fill();
+
+      if (item.id === state.selectedId) {
+        ctx.strokeStyle = '#ffffff';
+        ctx.lineWidth = 3;
+        ctx.stroke();
+      }
+
+      // Icon / label
+      const mid = (arcStart + arcEnd) / 2;
+      const textRadius = innerRadius + (outerRadius - innerRadius) * 0.55;
+      ctx.save();
+      ctx.translate(cx + Math.cos(mid) * textRadius, cy + Math.sin(mid) * textRadius);
+      ctx.rotate(mid + Math.PI / 2);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+
+      if (item.icon) {
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '600 24px "Inter", system-ui, sans-serif';
+        ctx.fillText(item.icon, 0, -12);
+      }
+
+      ctx.fillStyle = 'rgba(255,255,255,0.9)';
+      ctx.font = '600 16px "Inter", system-ui, sans-serif';
+      wrapText(ctx, item.label || '', 0, item.icon ? 12 : 0, outerRadius - innerRadius - 20, 18);
+
+      ctx.restore();
+
+      angle = end + gap;
+    });
+  }
+
+  function wrapText(context, text, x, y, maxWidth, lineHeight) {
+    if (!text) return;
+    const words = text.split(/\s+/);
+    let line = '';
+    const lines = [];
+
+    for (const word of words) {
+      const testLine = line ? `${line} ${word}` : word;
+      const metrics = context.measureText(testLine);
+      if (metrics.width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = testLine;
+      }
+    }
+    if (line) lines.push(line);
+
+    const offsetY = y - ((lines.length - 1) / 2) * lineHeight;
+    lines.forEach((l, index) => {
+      context.fillText(l, x, offsetY + index * lineHeight);
+    });
+  }
+
+  function shadeColour(hex, luminosity = 0) {
+    let col = hex.replace(/[^0-9a-f]/gi, '');
+    if (col.length < 6) {
+      col = col[0] + col[0] + col[1] + col[1] + col[2] + col[2];
+    }
+    let result = '#';
+    for (let i = 0; i < 3; i += 1) {
+      const part = parseInt(col.substr(i * 2, 2), 16);
+      const newPart = Math.max(Math.min(part + part * luminosity, 255), 0);
+      result += (`00${Math.round(newPart).toString(16)}`).substr(-2);
+    }
+    return result;
+  }
+
+  function persist() {
+    try {
+      const payload = {
+        ...state,
+        items: state.items.map((item) => ({ ...item }))
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (error) {
+      console.warn('Failed to save workspace', error);
+    }
+    updateJsonOutput();
+  }
+
+  function loadPersisted() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return false;
+      const saved = JSON.parse(raw);
+      if (!Array.isArray(saved.items)) return false;
+      state.items = saved.items.map((item) => ({ ...item }));
+      state.selectedId = saved.selectedId || (state.items[0]?.id ?? null);
+      state.innerRadius = typeof saved.innerRadius === 'number' ? saved.innerRadius : state.innerRadius;
+      state.gapAngle = typeof saved.gapAngle === 'number' ? saved.gapAngle : state.gapAngle;
+      state.backgroundColor = saved.backgroundColor || state.backgroundColor;
+      if (state.items.length) {
+        const lastId = state.items[state.items.length - 1].id;
+        const matches = /-(\d+)$/.exec(lastId || '');
+        if (matches) {
+          idCounter = Number(matches[1]) + 1;
+        }
+      }
+      return true;
+    } catch (error) {
+      console.warn('Could not load saved workspace', error);
+      return false;
+    }
+  }
+
+  function clearFileInput() {
+    if (elements.importFile) {
+      elements.importFile.value = '';
+    }
+  }
+
+  function updateJsonOutput() {
+    const payload = toExportPayload();
+    elements.jsonOutput.value = JSON.stringify(payload, null, 2);
+  }
+
+  function toExportPayload() {
+    return {
+      meta: {
+        name: 'Plasticity Radial Menu preset',
+        generatedAt: new Date().toISOString(),
+        innerRadius: state.innerRadius,
+        gapAngle: state.gapAngle,
+        backgroundColor: state.backgroundColor
+      },
+      items: state.items.map((item, index) => ({
+        id: index + 1,
+        label: item.label,
+        command: item.command,
+        keybind: item.keybind,
+        icon: item.icon,
+        color: item.color,
+        weight: item.weight
+      }))
+    };
+  }
+
+  function downloadJson() {
+    const payload = JSON.stringify(toExportPayload(), null, 2);
+    const blob = new Blob([payload], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'plasticity-radial-menu.json';
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  function copyJson() {
+    const payload = JSON.stringify(toExportPayload(), null, 2);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(payload).then(() => {
+        elements.copyJson.textContent = 'Copied!';
+        setTimeout(() => (elements.copyJson.textContent = 'Copy JSON'), 1600);
+      }).catch(() => {
+        elements.jsonOutput.value = payload;
+        alert('Clipboard is unavailable. The JSON is shown in the box below.');
+      });
+    } else {
+      elements.jsonOutput.value = payload;
+      elements.jsonOutput.select();
+      document.execCommand('copy');
+    }
+  }
+
+  function handleFileLoad() {
+    const file = elements.importFile.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const data = JSON.parse(event.target?.result ?? '{}');
+        if (!data || !Array.isArray(data.items)) {
+          throw new Error('Invalid preset file');
+        }
+        state.items = data.items.map((item) => createItem({ ...item }));
+        state.selectedId = state.items[0]?.id ?? null;
+        if (data.meta) {
+          if (typeof data.meta.innerRadius === 'number') state.innerRadius = data.meta.innerRadius;
+          if (typeof data.meta.gapAngle === 'number') state.gapAngle = data.meta.gapAngle;
+          if (typeof data.meta.backgroundColor === 'string') state.backgroundColor = data.meta.backgroundColor;
+        }
+        syncInputsFromState();
+        renderItemList();
+        updateItemEditor();
+        renderPreview();
+        persist();
+      } catch (error) {
+        alert(error.message || 'Unable to load preset.');
+      }
+      clearFileInput();
+    };
+    reader.readAsText(file);
+  }
+
+  function syncInputsFromState() {
+    elements.innerRadius.value = state.innerRadius;
+    elements.innerRadiusValue.textContent = `${Math.round(state.innerRadius * 100)}%`;
+    elements.gapAngle.value = state.gapAngle;
+    elements.gapAngleValue.textContent = `${Number(state.gapAngle).toFixed(1)}°`;
+    elements.backgroundColor.value = state.backgroundColor;
+  }
+
+  function attachEventListeners() {
+    elements.addItem.addEventListener('click', () => addItem());
+    elements.duplicateItem.addEventListener('click', duplicateSelected);
+    elements.removeItem.addEventListener('click', removeSelected);
+    elements.moveUp.addEventListener('click', () => moveSelected(-1));
+    elements.moveDown.addEventListener('click', () => moveSelected(1));
+
+    elements.itemLabel.addEventListener('input', (event) => {
+      const item = getSelectedItem();
+      if (!item) return;
+      item.label = event.target.value;
+      renderItemList();
+      renderPreview();
+      persist();
+    });
+
+    elements.itemCommand.addEventListener('input', (event) => {
+      const item = getSelectedItem();
+      if (!item) return;
+      item.command = event.target.value;
+      renderItemList();
+      persist();
+    });
+
+    elements.itemKeybind.addEventListener('input', (event) => {
+      const item = getSelectedItem();
+      if (!item) return;
+      item.keybind = event.target.value;
+      renderItemList();
+      persist();
+    });
+
+    elements.itemIcon.addEventListener('input', (event) => {
+      const item = getSelectedItem();
+      if (!item) return;
+      item.icon = event.target.value;
+      renderItemList();
+      renderPreview();
+      persist();
+    });
+
+    elements.itemColor.addEventListener('input', (event) => {
+      const item = getSelectedItem();
+      if (!item) return;
+      item.color = event.target.value;
+      renderItemList();
+      renderPreview();
+      persist();
+    });
+
+    elements.itemWeight.addEventListener('input', (event) => {
+      const item = getSelectedItem();
+      if (!item) return;
+      const value = Number(event.target.value);
+      item.weight = Math.max(1, Math.min(4, Number.isFinite(value) ? value : 1));
+      elements.itemWeightValue.textContent = `${item.weight}×`;
+      renderItemList();
+      renderPreview();
+      persist();
+    });
+
+    elements.innerRadius.addEventListener('input', (event) => {
+      const value = Number(event.target.value);
+      state.innerRadius = Math.max(0, Math.min(0.7, Number.isFinite(value) ? value : state.innerRadius));
+      elements.innerRadiusValue.textContent = `${Math.round(state.innerRadius * 100)}%`;
+      renderPreview();
+      persist();
+    });
+
+    elements.gapAngle.addEventListener('input', (event) => {
+      const value = Number(event.target.value);
+      state.gapAngle = Math.max(0, Math.min(8, Number.isFinite(value) ? value : state.gapAngle));
+      elements.gapAngleValue.textContent = `${state.gapAngle.toFixed(1)}°`;
+      renderPreview();
+      persist();
+    });
+
+    elements.backgroundColor.addEventListener('input', (event) => {
+      state.backgroundColor = event.target.value;
+      renderPreview();
+      persist();
+    });
+
+    elements.exportJson.addEventListener('click', downloadJson);
+    elements.copyJson.addEventListener('click', copyJson);
+    elements.loadJson.addEventListener('click', handleFileLoad);
+    elements.importFile.addEventListener('change', handleFileLoad);
+  }
+
+  function bootstrap() {
+    const hasSaved = loadPersisted();
+    if (!hasSaved) {
+      ['Modeling', 'Surface', 'Utility', 'Custom'].forEach((label, index) => {
+        const colourSet = ['#6dcff6', '#f76fc1', '#ffcd3c', '#7d7aff'];
+        addItem({ label, color: colourSet[index % colourSet.length], icon: label[0] });
+      });
+      state.innerRadius = 0.35;
+      state.gapAngle = 2;
+      state.backgroundColor = '#1b1d26';
+      selectItem(state.items[0]?.id ?? null);
+      renderItemList();
+      renderPreview();
+      persist();
+    } else {
+      renderItemList();
+      updateItemEditor();
+      renderPreview();
+      updateJsonOutput();
+    }
+    syncInputsFromState();
+  }
+
+  attachEventListeners();
+  bootstrap();
+})();

--- a/offline-radial-menu-editor/index.html
+++ b/offline-radial-menu-editor/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Plasticity Radial Menu Editor (Offline)</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Plasticity Radial Menu Editor</h1>
+    <p class="tagline">Offline-ready tool for building radial menu presets for Plasticity.</p>
+  </header>
+
+  <main>
+    <section class="column">
+      <h2>Menu Items</h2>
+      <div class="controls">
+        <button id="add-item">Add item</button>
+        <button id="duplicate-item" disabled>Duplicate</button>
+        <button id="remove-item" disabled>Remove</button>
+      </div>
+      <ul id="item-list" class="item-list" aria-live="polite"></ul>
+
+      <div id="item-editor" class="item-editor hidden" aria-live="polite">
+        <h3>Edit item</h3>
+        <label>
+          Label
+          <input type="text" id="item-label" maxlength="60" />
+        </label>
+        <label>
+          Command / Notes
+          <textarea id="item-command" rows="3"></textarea>
+        </label>
+        <label>
+          Key binding
+          <input type="text" id="item-keybind" maxlength="30" />
+        </label>
+        <label>
+          Icon text (emoji or short text)
+          <input type="text" id="item-icon" maxlength="4" />
+        </label>
+        <label class="color-picker">
+          Slice colour
+          <input type="color" id="item-color" />
+        </label>
+        <label class="slider">
+          Slice weight
+          <input type="range" id="item-weight" min="1" max="4" step="1" />
+          <span id="item-weight-value"></span>
+        </label>
+      </div>
+
+      <div class="ordering">
+        <button id="move-up" disabled>Move up</button>
+        <button id="move-down" disabled>Move down</button>
+      </div>
+
+      <div class="import-export">
+        <h3>Import / Export</h3>
+        <div class="import">
+          <label class="file-input">
+            <span>Select JSON file</span>
+            <input type="file" id="import-file" accept="application/json" />
+          </label>
+          <button id="load-json">Load</button>
+        </div>
+        <button id="export-json">Download preset</button>
+        <button id="copy-json">Copy JSON</button>
+        <textarea id="json-output" rows="8" readonly></textarea>
+      </div>
+    </section>
+
+    <section class="column preview">
+      <h2>Preview</h2>
+      <canvas id="menu-preview" width="520" height="520" role="img" aria-label="Radial menu preview"></canvas>
+      <div class="preview-options">
+        <label>
+          Inner radius
+          <input type="range" id="inner-radius" min="0" max="0.7" step="0.05" />
+          <span id="inner-radius-value"></span>
+        </label>
+        <label>
+          Gap between slices
+          <input type="range" id="gap-angle" min="0" max="8" step="0.5" />
+          <span id="gap-angle-value"></span>
+        </label>
+        <label>
+          Background
+          <input type="color" id="background-color" value="#1b1d26" />
+        </label>
+      </div>
+
+      <section class="help">
+        <h3>How to use</h3>
+        <ol>
+          <li>Click <strong>Add item</strong> to insert slices into the menu.</li>
+          <li>Select a slice in the list to edit its details and colour.</li>
+          <li>Use <strong>Move up</strong> / <strong>Move down</strong> to reorder slices around the circle.</li>
+          <li>Export your preset as JSON and drop it into Plasticity's radial menu configuration.</li>
+        </ol>
+      </section>
+    </section>
+  </main>
+
+  <footer>
+    <p>This project bundles every dependency locally so it can run entirely offline. Save this folder and open <code>index.html</code> in any modern browser.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/offline-radial-menu-editor/styles.css
+++ b/offline-radial-menu-editor/styles.css
@@ -1,0 +1,312 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --background: #11131b;
+  --surface: #1b1d26;
+  --surface-alt: #232634;
+  --accent: #6dcff6;
+  --text: #f5f7ff;
+  --text-muted: #b7bccf;
+  --border: rgba(255, 255, 255, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #22263a, var(--background));
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+}
+
+header,
+footer {
+  padding: 1.5rem 3vw;
+  background: rgba(5, 6, 8, 0.75);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 2.6vw, 2.5rem);
+}
+
+header .tagline {
+  margin-top: 0.25rem;
+  color: var(--text-muted);
+}
+
+main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(340px, 1fr);
+  gap: 1.5rem;
+  padding: 1.5rem 3vw 2rem;
+}
+
+.column {
+  background: rgba(17, 19, 27, 0.85);
+  padding: 1.25rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+h2,
+h3 {
+  margin: 0;
+}
+
+.controls,
+.ordering,
+.import-export,
+.preview-options,
+.help {
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: rgba(29, 31, 45, 0.9);
+}
+
+.controls,
+.ordering {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+button,
+.file-input span {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(49, 55, 78, 0.85);
+  color: var(--text);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.1s ease, background 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+}
+
+button:hover,
+.file-input:hover span {
+  background: rgba(96, 105, 150, 0.9);
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.item-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.item-list li {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(37, 41, 60, 0.9);
+  border: 1px solid transparent;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.item-list li.empty {
+  justify-content: center;
+  align-items: center;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.item-list li.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(109, 207, 246, 0.2);
+}
+
+.item-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.item-meta strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-meta .badge {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text-muted);
+}
+
+.item-details {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  min-height: 0.9rem;
+}
+
+.color-chip {
+  margin-top: 0.25rem;
+  width: 100%;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.item-editor label,
+.preview-options label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.item-editor input,
+.item-editor textarea,
+.preview-options input,
+#json-output {
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(16, 18, 24, 0.8);
+  color: var(--text);
+  font: inherit;
+}
+
+.item-editor textarea {
+  resize: vertical;
+}
+
+.slider {
+  align-items: center;
+}
+
+.slider input[type="range"] {
+  width: 100%;
+}
+
+.slider span {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+
+.file-input {
+  position: relative;
+  overflow: hidden;
+  display: inline-flex;
+}
+
+.file-input input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.import-export textarea {
+  margin-top: 0.75rem;
+  width: 100%;
+}
+
+.preview {
+  align-items: center;
+}
+
+canvas {
+  width: 100%;
+  height: auto;
+  border-radius: 16px;
+  background: #10121a;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.help ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: none;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 960px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .preview {
+    order: -1;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --background: #f2f4ff;
+    --surface: #ffffff;
+    --surface-alt: #f3f6ff;
+    --text: #1b2234;
+    --text-muted: #4f5979;
+    --border: rgba(15, 21, 45, 0.08);
+  }
+
+  body {
+    background: radial-gradient(circle at top left, #e4e9ff, #f7f9ff);
+  }
+
+  .column {
+    background: rgba(255, 255, 255, 0.9);
+  }
+
+  button,
+  .file-input span {
+    background: rgba(232, 236, 255, 0.9);
+    color: #1b2234;
+  }
+
+  button:hover,
+  .file-input:hover span {
+    background: rgba(202, 209, 245, 0.95);
+  }
+
+  canvas {
+    border-color: rgba(15, 21, 45, 0.12);
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone offline-ready clone of the Plasticity radial menu editor built with vanilla HTML, CSS, and JavaScript
- support editing menu slices, live canvas preview, JSON import/export, and local persistence
- document how to use the offline bundle from the repository README files

## Testing
- not run (static assets)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6913f0fe5e988333a0e8abd965951c19)