### PR TITLE
Add daily check-in script and scheduled GitHub Actions workflow

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -1,0 +1,28 @@
+name: Daily Check-in
+
+on:
+  schedule:
+    - cron: "0 23 * * *" # UTC 23:00 = 北京时间 07:00
+  workflow_dispatch:
+
+jobs:
+  checkin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run check-in
+        env:
+          CHECKIN_BASE_URL: ${{ secrets.CHECKIN_BASE_URL }}
+          CHECKIN_USERNAME: ${{ secrets.CHECKIN_USERNAME }}
+          CHECKIN_PASSWORD: ${{ secrets.CHECKIN_PASSWORD }}
+        run: python checkin.py

--- a/checkin.py
+++ b/checkin.py
@@ -1,0 +1,92 @@
+import os
+import sys
+from typing import Iterable
+
+import requests
+
+BASE_URL = os.getenv("CHECKIN_BASE_URL", "https://ai.xem8k5.top").rstrip("/")
+
+
+def _candidate_checkin_urls(base_url: str) -> Iterable[str]:
+    return (
+        f"{base_url}/api/user/aff_signin",
+        f"{base_url}/api/user/checkin",
+        f"{base_url}/api/user/sign",
+        f"{base_url}/api/checkin",
+    )
+
+
+def auto_checkin(username: str, password: str) -> int:
+    login_url = f"{BASE_URL}/api/user/login"
+    session = requests.Session()
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        "Content-Type": "application/json",
+    }
+
+    print("正在尝试登录...")
+    try:
+        res = session.post(
+            login_url,
+            json={"username": username, "password": password},
+            headers=headers,
+            timeout=20,
+        )
+    except requests.RequestException as exc:
+        print(f"❌ 登录请求出错: {exc}")
+        return 2
+
+    try:
+        payload = res.json()
+    except ValueError:
+        payload = {}
+
+    if res.status_code != 200 or not payload.get("success"):
+        print(f"❌ 登录失败 (HTTP {res.status_code}): {res.text[:200]}")
+        return 1
+
+    print("✅ 登录成功，开始探测签到接口…")
+
+    for url in _candidate_checkin_urls(BASE_URL):
+        print(f"[{url}] -> 正在探测...")
+        try:
+            resp = session.post(url, headers=headers, timeout=20)
+        except requests.RequestException as exc:
+            print(f"  请求失败: {exc}")
+            continue
+
+        if resp.status_code == 404:
+            print("  接口不存在 (404)")
+            continue
+
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+
+        if resp.status_code == 200 and data.get("success"):
+            print(f"🎉 签到成功！命中接口: {url}")
+            message = data.get("message")
+            if message:
+                print(f"服务器消息: {message}")
+            return 0
+
+        message = data.get("message", "") if isinstance(data, dict) else ""
+        print(f"  响应: HTTP {resp.status_code}; success={data.get('success') if isinstance(data, dict) else None}; message={message}")
+
+    print("\n⚠️ 未命中可用签到接口。")
+    print("建议：浏览器登录后打开开发者工具 Network，点击签到按钮抓包确认真实 API 路径。")
+    return 3
+
+
+def main() -> int:
+    username = os.getenv("CHECKIN_USERNAME")
+    password = os.getenv("CHECKIN_PASSWORD")
+    if not username or not password:
+        print("❌ 缺少环境变量 CHECKIN_USERNAME / CHECKIN_PASSWORD")
+        return 4
+    return auto_checkin(username, password)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Provide an automated daily check-in that runs at 07:00 Beijing time without requiring a device to be online by using a CI scheduler. 
- Probe common "New API" check-in endpoints and add robust error handling and timeouts to help discover the real API path when the site proxy uses different endpoints.

### Description
- Add `checkin.py`, a script that logs in to `CHECKIN_BASE_URL/api/user/login` using `requests.Session`, then probes candidate endpoints from `_candidate_checkin_urls` and prints structured diagnostic messages and exit codes.
- Credentials are read from environment variables `CHECKIN_USERNAME` and `CHECKIN_PASSWORD`, and the base URL can be overridden with `CHECKIN_BASE_URL` (default `https://ai.xem8k5.top`).
- Add `.github/workflows/checkin.yml` to schedule the script with `cron: "0 23 * * *"` (UTC 23:00 = Beijing 07:00) and support manual `workflow_dispatch`, with steps to set up Python, install `requests`, and run `python checkin.py` using repository secrets.
- Implement request timeouts, JSON parsing guards, and clearer logging for login, per-endpoint probing, and final diagnostic advice.

### Testing
- Ran `python -m py_compile checkin.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33b4643a083208621f569ead8803c)